### PR TITLE
Dyno restart race condition 🐎

### DIFF
--- a/lib/dyno.rb
+++ b/lib/dyno.rb
@@ -43,9 +43,14 @@ module DarkKnight
 
         @restarting = true
 
-        if RestartDyno.run(source).success?
-          logger.info("restarting dyno #{source}")
-        else
+        begin
+          if RestartDyno.run(source).success?
+            logger.info("restarting dyno #{source}")
+          else
+            @restarting = false
+          end
+        rescue Faraday::Error
+          # TODO: this should be handled by RestartDyno
           @restarting = false
         end
       end

--- a/lib/dyno.rb
+++ b/lib/dyno.rb
@@ -28,12 +28,6 @@ module DarkKnight
 
     attr_accessor :source, :memory_quota, :memory_total, :updated_at
 
-    def restart_if_swapping
-      return if restarting?
-
-      restart if swapping?
-    end
-
     def swapping?
       memory_total > memory_quota
     end
@@ -46,6 +40,8 @@ module DarkKnight
       response = RestartDyno.run(source)
       restarting! if response.success?
     end
+
+    private
 
     def restarting!
       logger.info("restarting dyno #{source}")

--- a/lib/dyno_repo.rb
+++ b/lib/dyno_repo.rb
@@ -29,7 +29,9 @@ module DarkKnight
     end
 
     def restart_dynos_if_swapping
-      dynos.each_value(&:restart_if_swapping)
+      dynos.each_value do |dyno|
+        dyno.restart if dyno.swapping?
+      end
     end
 
     attr_reader :dynos

--- a/spec/dyno_spec.rb
+++ b/spec/dyno_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe DarkKnight::Dyno do
   describe '#restart' do
-    it 'issues http request to heroku api' do
+    it 'issues restart request to heroku api' do
       stub_restart_request('todo', 'web.1')
 
       subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
@@ -12,6 +12,42 @@ RSpec.describe DarkKnight::Dyno do
       subject.restart
 
       expect_restart_request('todo', 'web.1')
+    end
+
+    it 'only issues one restart request to heroku api if first response succeeds' do
+      stub_restart_request('todo', 'web.1')
+
+      subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
+
+      Array.new(10) do
+        Thread.new do
+          subject.restart
+        end
+      end.each(&:join)
+
+      expect(a_restart_request('todo', 'web.1')).to have_been_made.once
+    end
+
+    it 'issues requests to heroku api until response succeeds' do
+      subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
+
+      stub_failed_restart_request('todo', 'web.1')
+
+      Array.new(2) do
+        Thread.new do
+          subject.restart
+        end
+      end.each(&:join)
+
+      stub_restart_request('todo', 'web.1')
+
+      Array.new(2) do
+        Thread.new do
+          subject.restart
+        end
+      end.each(&:join)
+
+      expect(a_restart_request('todo', 'web.1')).to have_been_made.times(3)
     end
   end
 

--- a/spec/dyno_spec.rb
+++ b/spec/dyno_spec.rb
@@ -3,42 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe DarkKnight::Dyno do
-  describe '#restart_if_swapping' do
-    it 'issues http request to heroku api if memory total exceeds memory quota' do
-      stub_restart_request('todo', 'web.1')
-
-      subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
-      subject.restart_if_swapping
-
-      expect_restart_request('todo', 'web.1')
-    end
-
-    it 'issues one http request to heroku api even if called multiple times' do
-      stub_restart_request('todo', 'web.1')
-
-      subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
-      2.times { subject.restart_if_swapping }
-
-      expect_restart_request('todo', 'web.1')
-    end
-
-    it 'does nothing if memory total equals memory quota' do
-      subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 512.0)
-
-      subject.restart_if_swapping
-
-      expect_no_request
-    end
-
-    it 'does nothing false if memory total is lower than memory quota' do
-      subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 256.0)
-
-      subject.restart_if_swapping
-
-      expect_no_request
-    end
-  end
-
   describe '#restart' do
     it 'issues http request to heroku api' do
       stub_restart_request('todo', 'web.1')

--- a/spec/dyno_spec.rb
+++ b/spec/dyno_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe DarkKnight::Dyno do
   describe '#restart' do
     it 'issues restart request to heroku api' do
-      stub_restart_request('todo', 'web.1')
+      stub_successful_restart_request('todo', 'web.1')
 
       subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
 
@@ -15,7 +15,7 @@ RSpec.describe DarkKnight::Dyno do
     end
 
     it 'only issues one restart request to heroku api if first response succeeds' do
-      stub_restart_request('todo', 'web.1')
+      stub_successful_restart_request('todo', 'web.1')
 
       subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
 
@@ -39,7 +39,7 @@ RSpec.describe DarkKnight::Dyno do
         end
       end.each(&:join)
 
-      stub_restart_request('todo', 'web.1')
+      stub_successful_restart_request('todo', 'web.1')
 
       Array.new(2) do
         Thread.new do
@@ -48,6 +48,20 @@ RSpec.describe DarkKnight::Dyno do
       end.each(&:join)
 
       expect(a_restart_request('todo', 'web.1')).to have_been_made.times(3)
+    end
+
+    it 'recovers from Faraday exceptions' do
+      # TODO: this should be a spec on RestartDyno
+
+      subject = described_class.new(source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
+
+      stub_restart_request('todo', 'web.1').to_timeout
+      subject.restart
+
+      stub_successful_restart_request('todo', 'web.1')
+      subject.restart
+
+      expect(a_restart_request('todo', 'web.1')).to have_been_made.twice
     end
   end
 

--- a/spec/support/helpers/restart_helpers.rb
+++ b/spec/support/helpers/restart_helpers.rb
@@ -7,10 +7,19 @@ module RestartHelpers
       .to_return(status: 202)
   end
 
+  def stub_failed_restart_request(app_id_or_name, dyno_id_or_name)
+    stub_request(:delete, restart_uri(app_id_or_name, dyno_id_or_name))
+      .with(headers: restart_headers)
+      .to_return(status: 500)
+  end
+
   def expect_restart_request(app_id_or_name, dyno_id_or_name)
-    expect(a_request(:delete, restart_uri(app_id_or_name, dyno_id_or_name))
-      .with(headers: restart_headers))
-      .to have_been_made.once
+    expect(a_restart_request(app_id_or_name, dyno_id_or_name)).to have_been_made.once
+  end
+
+  def a_restart_request(app_id_or_name, dyno_id_or_name)
+    a_request(:delete, restart_uri(app_id_or_name, dyno_id_or_name))
+      .with(headers: restart_headers)
   end
 
   def expect_no_request

--- a/spec/support/helpers/restart_helpers.rb
+++ b/spec/support/helpers/restart_helpers.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 module RestartHelpers
-  def stub_restart_request(app_id_or_name, dyno_id_or_name)
-    stub_request(:delete, restart_uri(app_id_or_name, dyno_id_or_name))
-      .with(headers: restart_headers)
-      .to_return(status: 202)
+  def stub_successful_restart_request(app_id_or_name, dyno_id_or_name)
+    stub_restart_request(app_id_or_name, dyno_id_or_name).to_return(status: 202)
   end
 
   def stub_failed_restart_request(app_id_or_name, dyno_id_or_name)
-    stub_request(:delete, restart_uri(app_id_or_name, dyno_id_or_name))
-      .with(headers: restart_headers)
-      .to_return(status: 500)
+    stub_restart_request(app_id_or_name, dyno_id_or_name).to_return(status: 500)
   end
 
   def expect_restart_request(app_id_or_name, dyno_id_or_name)
     expect(a_restart_request(app_id_or_name, dyno_id_or_name)).to have_been_made.once
+  end
+
+  def stub_restart_request(app_id_or_name, dyno_id_or_name)
+    stub_request(:delete, restart_uri(app_id_or_name, dyno_id_or_name)).with(headers: restart_headers)
   end
 
   def a_restart_request(app_id_or_name, dyno_id_or_name)


### PR DESCRIPTION
This fixes a race condition which occurs when running puma with more than one thread.

https://github.com/karlentwistle/dark_knight/blob/826729303ed473146386e700f205f0450f6c3eda/lib/dyno.rb#L45-L48

Within the `restart` function, we're setting `@restarting = true` **after** executing the blocking call to `RestartDyno`. This is fine in a single-threaded mode. In in a multi-threaded mode, it means if `n` number of threads call this function, depending on where the other threads are in relation to the blocking call, `@restarting` may or may not be set. Meaning that multiple threads can incorrectly issue the restart request to Heroku.

This PR resolve this issue.
