### PR TITLE
Avoid deleting SourceRestartLocks

### DIFF
--- a/lib/dyno.rb
+++ b/lib/dyno.rb
@@ -34,7 +34,7 @@ module DarkKnight
     def restart
       return if locked?
 
-      SourceRestartLock.create(source:)
+      SourceRestartLock.update_or_create_by(source)
       RestartDynoJob.perform_async(self)
     end
 
@@ -45,7 +45,7 @@ module DarkKnight
     private
 
     def locked?
-      SourceRestartLock.where(source:).count >= 1
+      SourceRestartLock.source_locked?(source)
     end
 
     def fetch_restart_threshold

--- a/lib/runtime_metric_importer.rb
+++ b/lib/runtime_metric_importer.rb
@@ -18,7 +18,6 @@ module DarkKnight
     end
 
     def delete_expired
-      SourceRestartLock.delete_expired
       Dyno.delete_expired
     end
 


### PR DESCRIPTION
We can "indefinitely" persist `SourceRestartLock` records because it's highly unlikely there will be many of them. This avoids having to delete them on each request.