### PR TITLE
Disk backed storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+/db/*.sqlite
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/db/migrations/1_create_dynos.rb
+++ b/db/migrations/1_create_dynos.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table :dynos do
+      String :dyno, null: false, index: { unique: true }
+      String :source, null: false
+      Integer :memory_quota, null: false
+      Integer :memory_total, null: false
+      Integer :restart_threshold, null: false
+      DateTime :updated_at, null: false
+    end
+  end
+
+  down do
+    drop_table(:dyno)
+  end
+end

--- a/db/migrations/2_create_source_restart_locks.rb
+++ b/db/migrations/2_create_source_restart_locks.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table :source_restart_locks do
+      String :source, null: false, index: { unique: true }
+      DateTime :expires_at, null: false
+      Integer :lock_version, default: 0
+    end
+  end
+
+  down do
+    drop_table(:source_restart_locks)
+  end
+end

--- a/lib/database.rb
+++ b/lib/database.rb
@@ -1,19 +1,9 @@
 # frozen_string_literal: true
 
 module DarkKnight
-  DB = Sequel.sqlite
+  DB = Sequel.sqlite(File.join(File.dirname(__FILE__), '../db/dark_knight.sqlite'))
 
-  DB.create_table :dynos do
-    String :dyno, null: false, index: { unique: true }
-    String :source, null: false
-    Integer :memory_quota, null: false
-    Integer :memory_total, null: false
-    Integer :restart_threshold, null: false
-    DateTime :updated_at, null: false
-  end
+  Sequel.extension :migration
 
-  DB.create_table :source_restart_locks do
-    String :source, null: false, index: { unique: true }
-    DateTime :expires_at, null: false
-  end
+  Sequel::Migrator.run(DB, 'db/migrations', target: 2)
 end


### PR DESCRIPTION
> SQLite runs in memory, and backs up its data store in files on disk. While this strategy works well for development, Heroku’s Cedar stack has an [ephemeral filesystem](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem). You can write to it, and you can read from it, but the contents will be cleared periodically. If you were to use SQLite on Heroku, you would lose your entire database at least once every 24 hours.
>
> Even if Heroku’s disks were persistent running SQLite would still not be a good fit. Since SQLite does not run as a service, each dyno would run a separate running copy. Each of these copies need their own disk backed store. This would mean that each dyno powering your app would have a different set of data since the disks are not synchronized.
Instead of using SQLite on Heroku you can configure your app to run on Postgres.

~ https://devcenter.heroku.com/articles/sqlite3

> If you were to use SQLite on Heroku, you would lose your entire database at least once every 24 hours.

This is ok because the database is constantly reset. After all, it's following a log drain.

> Even if Heroku’s disks were persistent running SQLite would still not be a good fit. Since SQLite does not run as a service, each dyno would run a separate running copy.

This is also ok because the project is intended to run on a single basic Heroku dyno.