### PR TITLE
Avoid duplicate dyno restarts

### DIFF
--- a/lib/application.rb
+++ b/lib/application.rb
@@ -33,7 +33,6 @@ module DarkKnight
         end
 
         route do |r|
-          # POST /logs
           r.post 'logs' do
             controller = LogController.new
             response.status, body = controller.call(request)

--- a/lib/dyno.rb
+++ b/lib/dyno.rb
@@ -32,10 +32,9 @@ module DarkKnight
     end
 
     def restart
-      return if locked?
-
-      SourceRestartLock.update_or_create_by(source)
-      RestartDynoJob.perform_async(self)
+      SourceRestartLock.if_source_unlocked(source) do
+        RestartDynoJob.perform_async(self)
+      end
     end
 
     def restart_failed

--- a/spec/source_restart_lock_spec.rb
+++ b/spec/source_restart_lock_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DarkKnight::SourceRestartLock do
+  describe '.if_source_unlocked' do
+    it 'yields block if no source restart lock exists' do
+      expect { |b| described_class.if_source_unlocked('web.1', &b) }.to yield_control
+    end
+
+    it 'yields if source restart lock exists but the lock has expired' do
+      described_class.create(source: 'web.1', expires_at: one_day_ago)
+
+      expect { |b| described_class.if_source_unlocked('web.1', &b) }.to yield_control
+    end
+
+    it 'doesnt yield block if source restart lock already exists and hasnt expired' do
+      described_class.create(source: 'web.1', expires_at: one_minute_from_now)
+
+      expect { |b| described_class.if_source_unlocked('web.1', &b) }.not_to yield_control
+    end
+
+    it 'doesnt yield block if Sequel::Plugins::OptimisticLocking::Error is thrown' do
+      dbl = double(expires_at: one_day_ago, fetch_expires_at: one_minute_from_now)
+      allow(dbl).to receive(:update).and_raise(Sequel::Plugins::OptimisticLocking::Error)
+      allow(described_class).to receive(:find).with(source: 'web.1').and_return(dbl)
+
+      expect { |b| described_class.if_source_unlocked('web.1', &b) }.not_to yield_control
+    end
+  end
+
+  private
+
+  def one_day_ago
+    Time.now - (24 * 60 * 60)
+  end
+
+  def one_minute_from_now
+    Time.now + 60
+  end
+end


### PR DESCRIPTION
We sometimes see a duplicate dyno restart. 

![Screenshot 2023-02-24 at 22 32 30](https://user-images.githubusercontent.com/666397/221307260-d8dd0430-c4fe-4aa8-9266-9d5ceed8db13.png)

This is due to a race condition that can occur between:

```ruby
return if locked?

SourceRestartLock.update_or_create_by(source)
RestartDynoJob.perform_async(self)
```

Where two requests see `locked?` is false, either via 

- one request creating a new restart lock, and the other request updating the created restart lock.
- one request updating an existing restart lock, and the other request updating the existing restart lock.

In both situations, `RestartDynoJob` would erroneously be triggered twice.

This attempts to avoid this situation by utilizing `optimistic_locking` so only one request can create or update a restart lock.

We use a block that can be yielded as a control flow.