### PR TITLE
Avoid incorrectly restarting the same Dyno multiple times

### DIFF
--- a/db/migrations/1_create_dynos.rb
+++ b/db/migrations/1_create_dynos.rb
@@ -9,6 +9,8 @@ Sequel.migration do
       Integer :memory_total, null: false
       Integer :restart_threshold, null: false
       DateTime :updated_at, null: false
+      Boolean :restarting, null: false, default: false
+      Integer :lock_version, default: 0
     end
   end
 

--- a/lib/source_restart_lock.rb
+++ b/lib/source_restart_lock.rb
@@ -4,21 +4,21 @@ module DarkKnight
   class SourceRestartLock < Sequel::Model
     set_primary_key [:source]
     unrestrict_primary_key
-    plugin :validation_helpers
     plugin :optimistic_locking
+    plugin :update_or_create
+    plugin :validation_helpers
 
-    def self.if_source_unlocked(source)
-      if (existing = find(source:))
-        if existing.expires_at < Time.now
-          begin
-            existing.update(expires_at: existing.fetch_expires_at)
-            yield existing
-          rescue Sequel::Plugins::OptimisticLocking::Error
-            # no yield
-          end
-        end
-      else
-        yield create(source:)
+    def self.source_unlocked?(source)
+      where(source:).where { expires_at > Time.now }.none?
+    end
+
+    def self.source_locked?(source)
+      !source_unlocked?(source)
+    end
+
+    def self.lock_source(source)
+      update_or_create(source:) do |lock|
+        lock.expires_at = lock.fetch_expires_at
       end
     end
 
@@ -26,11 +26,6 @@ module DarkKnight
       super
       validates_presence %i[source expires_at]
       validates_unique :source
-    end
-
-    def before_validation
-      self.expires_at ||= fetch_expires_at
-      super
     end
 
     def process_type

--- a/spec/dyno_spec.rb
+++ b/spec/dyno_spec.rb
@@ -63,5 +63,18 @@ RSpec.describe DarkKnight::Dyno do
 
       expect(a_restart_request('todo', 'web.1')).to have_been_made.once
     end
+
+    it 'wont issue duplicate restarts for the same dyno uuid' do
+      stub_successful_restart_request('todo', 'web.1')
+
+      subject = described_class.create(dyno: 'uuid', source: 'web.1', memory_quota: 512.00, memory_total: 513.5)
+
+      with_env('WEB_RESTART_WINDOW', '-1') do
+        subject.restart
+        subject.restart
+      end
+
+      expect(a_restart_request('todo', 'web.1')).to have_been_made.once
+    end
   end
 end

--- a/spec/features/restart_window_spec.rb
+++ b/spec/features/restart_window_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe '{DYNO_TYPE}_RESTART_WINDOW' do
           post('/logs', log_fixture('web.1.out_of_memory'))
         end
 
-        post('/logs', log_fixture('web.1'))
-        post('/logs', log_fixture('web.1.out_of_memory'))
+        post('/logs', log_fixture('web.1.new_dyno'))
+        post('/logs', log_fixture('web.1.new_dyno.out_of_memory'))
       end
     end
 

--- a/spec/source_restart_lock_spec.rb
+++ b/spec/source_restart_lock_spec.rb
@@ -3,29 +3,21 @@
 require 'spec_helper'
 
 RSpec.describe DarkKnight::SourceRestartLock do
-  describe '.if_source_unlocked' do
-    it 'yields block if no source restart lock exists' do
-      expect { |b| described_class.if_source_unlocked('web.1', &b) }.to yield_control
+  describe '.source_unlocked?' do
+    it 'returns true no source restart lock exists' do
+      expect(described_class.source_unlocked?('web.1')).to eql(true)
     end
 
-    it 'yields if source restart lock exists but the lock has expired' do
+    it 'returns true if source restart lock exists but the lock has expired' do
       described_class.create(source: 'web.1', expires_at: one_day_ago)
 
-      expect { |b| described_class.if_source_unlocked('web.1', &b) }.to yield_control
+      expect(described_class.source_unlocked?('web.1')).to eql(true)
     end
 
-    it 'doesnt yield block if source restart lock already exists and hasnt expired' do
+    it 'returns false if source restart lock already exists and hasnt expired' do
       described_class.create(source: 'web.1', expires_at: one_minute_from_now)
 
-      expect { |b| described_class.if_source_unlocked('web.1', &b) }.not_to yield_control
-    end
-
-    it 'doesnt yield block if Sequel::Plugins::OptimisticLocking::Error is thrown' do
-      dbl = double(expires_at: one_day_ago, fetch_expires_at: one_minute_from_now)
-      allow(dbl).to receive(:update).and_raise(Sequel::Plugins::OptimisticLocking::Error)
-      allow(described_class).to receive(:find).with(source: 'web.1').and_return(dbl)
-
-      expect { |b| described_class.if_source_unlocked('web.1', &b) }.not_to yield_control
+      expect(described_class.source_unlocked?('web.1')).to eql(false)
     end
   end
 

--- a/spec/support/fixtures/runtime_metrics/web.1.new_dyno
+++ b/spec/support/fixtures/runtime_metrics/web.1.new_dyno
@@ -1,0 +1,1 @@
+327 <134>1 2023-02-13T22:12:51.822974+00:00 host heroku web.1 - source=web.1 dyno=heroku.15253441.cfe2c338-81f4-40d4-bfb2-13f4e5e31fcf sample#memory_total=256.80MB sample#memory_rss=1.25MB sample#memory_cache=4.55MB sample#memory_swap=0.00MB sample#memory_pgpgin=1651pages sample#memory_pgpgout=165pages sample#memory_quota=512.00MB

--- a/spec/support/fixtures/runtime_metrics/web.1.new_dyno.out_of_memory
+++ b/spec/support/fixtures/runtime_metrics/web.1.new_dyno.out_of_memory
@@ -1,0 +1,1 @@
+327 <134>1 2023-02-13T22:12:51.822974+00:00 host heroku web.1 - source=web.1 dyno=heroku.15253441.cfe2c338-81f4-40d4-bfb2-13f4e5e31fcf sample#memory_total=768.00MB sample#memory_rss=1.25MB sample#memory_cache=4.55MB sample#memory_swap=0.00MB sample#memory_pgpgin=1651pages sample#memory_pgpgout=165pages sample#memory_quota=512.00MB


### PR DESCRIPTION
There can be a situation where a dyno incorrectly attempts to restart itself twice.

![Screenshot 2023-03-02 at 16 18 01](https://user-images.githubusercontent.com/666397/222487090-454f03c6-3fed-43ef-b9ec-490722f55610.png)

Since we instruct Heroku to restart via a dyno source `web.1`, `slow_worker.2` etc., a healthy dyno can be incorrectly ordered to restart.

Once a restart to Heroku is issued, the dyno UUID changes. 

For example:

```
dyno heroku.295370598.1f262b4b-98d4-452c-aff2-1d441a8c4a3c
dyno heroku.295370598.1f262b4b-98d4-452c-aff2-1d441a8c4a3c
dyno heroku.295370598.1f262b4b-98d4-452c-aff2-1d441a8c4a3c
restarting dyno web.1
dyno heroku.295370598.86403a18-7c56-48f4-83b7-a899756bd9d6
dyno heroku.295370598.86403a18-7c56-48f4-83b7-a899756bd9d6
```

With this in mind, we only need to issue a restart once per dyno UUID. This change adds a restarting boolean attribute on each Dyno instance (with UUID as their primary key). If a dyno instance is already restarting, we won't attempt to restart it again.